### PR TITLE
removes mavenLocal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
 allprojects {
     repositories {
         maven       { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
-        mavenLocal  ()
         mavenCentral()
     }
 }


### PR DESCRIPTION
## Why is this happening?
mavenLocal was blocking the download of mpp libraries after a first run of the desktop app. which meant that it was impossible to run the js version of the app after since the mpp versions of libraries were not being fetched. this manifested as a compile time error for unresolved dependencies and a dependency tree that showed only jvm libraries in a javascript context as such:

```
jsCompileClasspath - Compile classpath for compilation 'main' (target js (js)).
+--- project :Calculator
|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0
|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.0
|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0
|    |              +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.0
|    |              |    \--- org.jetbrains:annotations:13.0
|    |              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.0
|    |                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.0 (*)
```

## How is it being fixed?
by removing `mavenLocal` from the gradle settings.